### PR TITLE
Try to fix https://dev.plone.org/ticket/12949

### DIFF
--- a/Products/CMFEditions/StandardModifiers.py
+++ b/Products/CMFEditions/StandardModifiers.py
@@ -1187,7 +1187,16 @@ class CloneBlobs:
             save_new = True
             if prior_rev is not None:
                 prior_obj = prior_rev.object
-                prior_blob = f.get(prior_obj, raw=True).getBlob()
+                #prior_blob = f.get(prior_obj, raw=True).getBlob()
+
+                # Skip if it is 'NoneType' object
+                prior_raw_obj = f.get(prior_obj, raw=True)
+                if prior_raw_obj is None:
+                    continue
+                prior_blob = prior_raw_obj.getBlob()
+                if prior_blob is None:
+                    continue
+
                 prior_file = prior_blob.open('r')
                 # Check for file size differences
                 if (os.fstat(prior_file.fileno()).st_size ==
@@ -1215,7 +1224,16 @@ class CloneBlobs:
     def reattachReferencedAttributes(self, obj, attrs_dict):
         obj = aq_base(obj)
         for name, blob in attrs_dict.iteritems():
-            obj.getField(name).get(obj).setBlob(blob)
+            #obj.getField(name).get(obj).setBlob(blob)
+
+            # Skip if it is 'NoneType' object
+            prior_name = obj.getField(name)
+            if prior_name is None:
+                continue
+            prior_obj = prior_name.get(obj)
+            if prior_obj is None:
+                continue
+            prior_obj.setBlob(blob)
 
     def getOnCloneModifiers(self, obj):
         """Removes references to blobs.


### PR DESCRIPTION
We are facing an exception when 'check out' file view that have lead image using collective.contentleadimage package. Currently my fix is make sure the object is not NoneType before calling getBlob, setBlob and open. I don't understand the code enough, and not sure it will cause any other problems. Please help to review and guidance. Thank you.