### PR TITLE
revert of last fix + more consistent behaviour between image, file and other content

### DIFF
--- a/Products/CMFEditions/skins/CMFEditions/versions_history_form.pt
+++ b/Products/CMFEditions/skins/CMFEditions/versions_history_form.pt
@@ -210,6 +210,12 @@
                          object_title context/Title;
                          suppress_preview python:True;
                          view_macro python:version_view_macro;">
+
+        <div tal:replace="structure provider:plone.belowcontenttitle" />
+
+        <h1 class="documentFirstHeading" tal:content="vdata/object/Title"/>
+        <div class="documentDescription" tal:content="vdata/object/Description"></div>
+
         <tal:preview condition="view_macro">
           <metal:use_body use-macro="view_macro" />
         </tal:preview>

--- a/Products/CMFEditions/skins/cmfeditions_views/version_file_view.pt
+++ b/Products/CMFEditions/skins/cmfeditions_views/version_file_view.pt
@@ -12,18 +12,6 @@
                        content_type context/get_content_type|context/Format;
                       ">
 
-        <h1 tal:content="object_title" class="documentFirstHeading">
-            Title or id
-        </h1>
-
-        <div tal:replace="structure provider:plone.belowcontenttitle" />
-
-        <div class="documentDescription"
-           tal:content="context/Description"
-           tal:condition="context/Description">
-            Description
-        </div>
-
         <div id="content-core">
             <p tal:condition="size_value">
                 <a href=""

--- a/Products/CMFEditions/skins/cmfeditions_views/version_image_view.pt
+++ b/Products/CMFEditions/skins/cmfeditions_views/version_image_view.pt
@@ -10,18 +10,6 @@
                     tal:define="size here/size;
                                 here_url context/absolute_url;">
 
-        <h1 tal:content="object_title" class="documentFirstHeading">
-            Title or id
-        </h1>
-
-        <div tal:replace="structure provider:plone.belowcontenttitle" />
-
-        <div class="documentDescription"
-           tal:content="here/Description"
-           tal:condition="here/Description">
-            Description
-        </div>
-
         <div id="content-core">
             <a href=""
                class="discreet"


### PR DESCRIPTION
we don't see title + description anymore

we change our strategy : title + description has to be removed
from version_file_view and version_image_view, not from main history
view
document byline is moved into form, so we see it on every type
