### PR TITLE
Fix bug: ``CopyModifyMergeRepositoryTool.manage_setTypePolicies`` method modifies sequence while iterating over it.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 2.2.10 (unreleased)
 -------------------
 
+- Fix bug: ``CopyModifyMergeRepositoryTool.manage_setTypePolicies`` method
+  modifies sequence while iterating over it.
+  [rafaelbco]
+
 - Purging old versions did not properly remove all references
   to the blob fields, resulting in old blobs to stay there forever.
   [do3cc]

--- a/Products/CMFEditions/CopyModifyMergeRepositoryTool.py
+++ b/Products/CMFEditions/CopyModifyMergeRepositoryTool.py
@@ -187,7 +187,7 @@ class CopyModifyMergeRepositoryTool(UniqueObject,
     def manage_setTypePolicies(self, policy_map, **kw):
         assert isinstance(policy_map, dict)
         for p_type, policies in self._version_policy_mapping.items():
-            for policy_id in policies:
+            for policy_id in list(policies):
                 self.removePolicyFromContentType(p_type, policy_id, **kw)
         for p_type, policies in policy_map.items():
             assert isinstance(policies, list), \

--- a/Products/CMFEditions/tests/test_CopyModifyMergeRepositoryTool.py
+++ b/Products/CMFEditions/tests/test_CopyModifyMergeRepositoryTool.py
@@ -473,6 +473,21 @@ class TestPolicyVersioning(TestCopyModifyMergeRepositoryToolBase):
         self.failUnless(portal_repository.supportsPolicy(self.portal.doc,
                                                        'at_edit_autoversion'))
 
+        # assign two policies and then unassign them.
+        # this demonstrates a bug related to modifying the list of policies
+        # of a type while iterating through it.
+        portal_repository.addPolicy('version_on_publish',
+                                            'Create version when published')
+        portal_repository.manage_setTypePolicies({'Document': [
+                                                    'at_edit_autoversion',
+                                                    'version_on_publish']})
+        portal_repository.manage_setTypePolicies({'Document': []})
+        self.failIf(portal_repository.supportsPolicy(self.portal.doc,
+                                                       'at_edit_autoversion'))
+        self.failIf(portal_repository.supportsPolicy(self.portal.doc,
+                                                       'version_on_publish'))
+
+
     def test04_add_policy(self):
         # test adding a new policy
         portal_repository = self.portal.portal_repository


### PR DESCRIPTION
Added test to demonstrate the problem.
