### PR TITLE
Input sanitation for retrieveSubstitute()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,15 @@ Changelog
 2.2.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Input sanitation for retrieveSubstitute()
+  [zupo]
 
 
 2.2.15 (2015-09-15)
 -------------------
 
-- use unrestricted search for storage statistics [tschorr]
+- use unrestricted search for storage statistics
+  [tschorr]
 
 
 2.2.14 (2015-08-13)

--- a/Products/CMFEditions/KeepLastNVersionsTool.py
+++ b/Products/CMFEditions/KeepLastNVersionsTool.py
@@ -96,7 +96,10 @@ class KeepLastNVersionsTool(UniqueObject, SimpleItem, PropertyManager):
 
         If there isn't a next older one returns the next newer one.
         """
-        selector = int(selector)
+        if selector is None:
+            selector = 0
+        else:
+            selector = int(selector)
         storage = getToolByName(self, 'portal_historiesstorage')
         savedSelector = selector
         while selector:

--- a/Products/CMFEditions/ZVCStorageTool.py
+++ b/Products/CMFEditions/ZVCStorageTool.py
@@ -673,8 +673,11 @@ class ZVCStorageTool(UniqueObject, SimpleItem):
             else:
                 path = None
                 url = None
-                retrieved = self.retrieve(hid).object.object
-                portal_type = retrieved.getPortalTypeName()
+                object_ = self.retrieve(hid).object
+                if isinstance(object_, Removed):
+                    portal_type = 'Removed'
+                else:
+                    portal_type = object_.object.getPortalTypeName()
             histData = {
                 "history_id": hid,
                 "length": length,


### PR DESCRIPTION
Under some conditions, like when calculating summary of histories on old sites
with lots of stale/broken objects, the selector is None and the
retrieveSubstitute() breaks when casting None to int. This fixes this by
setting selector to 0 if selector parameter is None.