### PR TITLE
use unrestricted catalog search for storage statistics

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.2.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- use unrestricted search for storage statistics [tschorr]
 
 
 2.2.14 (2015-08-13)

--- a/Products/CMFEditions/ZVCStorageTool.py
+++ b/Products/CMFEditions/ZVCStorageTool.py
@@ -665,7 +665,7 @@ class ZVCStorageTool(UniqueObject, SimpleItem):
             if shadowStorage is not None:
                 size, sizeState = shadowStorage.getSize()
 
-            workingCopy = hidhandler.queryObject(hid)
+            workingCopy = hidhandler.unrestrictedQueryObject(hid)
             if workingCopy is not None:
                 url = workingCopy.absolute_url()
                 path = url[portal_paths_len:]

--- a/Products/CMFEditions/tests/test_ZVCStorageTool.py
+++ b/Products/CMFEditions/tests/test_ZVCStorageTool.py
@@ -484,30 +484,40 @@ class TestZVCStorageTool(CMFEditionsBaseTestCase):
         cmf_uid = 2
         tomorrow = DateTime() + 1
         obj5 = CMFDummy('tomorrow', cmf_uid, effective=tomorrow)
+        obj5.allowedRolesAndUsers = ['Anonymous']
         self.portal._setObject('tomorrow', obj5)
         self.portal.portal_catalog.indexObject(self.portal.tomorrow)
         portal_storage.register(cmf_uid, ObjectData(obj5), metadata=self.buildMetadata('effective tomorrow'))
 
         cmf_uid = 3
         yesterday = DateTime() - 1
-        obj5 = CMFDummy('yesterday', cmf_uid, expires=yesterday)
-        self.portal._setObject('yesterday', obj5)
+        obj6 = CMFDummy('yesterday', cmf_uid, expires=yesterday)
+        obj6.allowedRolesAndUsers = ['Anonymous']
+        self.portal._setObject('yesterday', obj6)
         self.portal.portal_catalog.indexObject(self.portal.yesterday)
-        portal_storage.register(cmf_uid, ObjectData(obj5), metadata=self.buildMetadata('expired yesterday'))
+        portal_storage.register(cmf_uid, ObjectData(obj6), metadata=self.buildMetadata('expired yesterday'))
+
+        cmf_uid = 4
+        obj7 = CMFDummy('public', cmf_uid)
+        obj7.text = 'visible for everyone'
+        obj7.allowedRolesAndUsers = ['Anonymous']
+        self.portal._setObject('public', obj7)
+        self.portal.portal_catalog.indexObject(self.portal.public)
+        portal_storage.register(cmf_uid, ObjectData(obj7), metadata=self.buildMetadata('saved public'))
 
         got = portal_storage.zmi_getStorageStatistics()
         expected = {'deleted': [], 
                     'summaries': {
-                        'totalHistories': 3, 
+                        'totalHistories': 4, 
                         'deletedVersions': 0, 
-                        'existingVersions': 6, 
+                        'existingVersions': 7, 
                         'deletedHistories': 0, 
                         'time': '0.00', 
-                        'totalVersions': 6, 
-                        'existingAverage': '2.0', 
-                        'existingHistories': 3, 
+                        'totalVersions': 7, 
+                        'existingAverage': '1.8', 
+                        'existingHistories': 4, 
                         'deletedAverage': 'n/a', 
-                        'totalAverage': '2.0'}, 
+                        'totalAverage': '1.8'}, 
                     'existing': [
                         {
                             'url': 'http://nohost/plone/obj', 
@@ -524,7 +534,7 @@ class TestZVCStorageTool(CMFEditionsBaseTestCase):
                             'path': '/tomorrow', 
                             'sizeState': 'approximate', 
                             'portal_type': 'Dummy', 
-                            'size': 514
+                            'size': 555
                         }, {
                             'url': 'http://nohost/plone/yesterday', 
                             'history_id': 3, 
@@ -532,7 +542,15 @@ class TestZVCStorageTool(CMFEditionsBaseTestCase):
                             'path': '/yesterday', 
                             'sizeState': 'approximate', 
                             'portal_type': 'Dummy', 
-                            'size': 516
+                            'size': 557
+                        }, {
+                            'url': 'http://nohost/plone/public', 
+                            'history_id': 4, 
+                            'length': 1, 
+                            'path': '/public', 
+                            'sizeState': 'approximate', 
+                            'portal_type': 'Dummy', 
+                            'size': 557
                         }]}
         self.assertEqual(expected, got)
 


### PR DESCRIPTION
ZVCStorageTool.zmi_getStorageStatistics uses a restricted search to determine histories with deleted working copy. Histories for objects that are not visible for various reasons (roles, effective/expiration dates) are therefore listed as histories with deleted working copy.