### PR TITLE
Fixed CloneBlobs modifier to only react on Archetypes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fixed CloneBlobs modifier to only react on Archetypes.
+  This fix allows Dexterity Blob-Types (e.g. File, Image) to be versioned.
+  [iham]
 
 
 2.2.19 (2016-02-14)


### PR DESCRIPTION
CloneBlobs assumes Archetypes exist and picks the objects Schema without further investigation.
When versioning a dexterity based blob type (File, Image, ...) this modifier fails.

I've added a check to if the archetypes basecontent interface is present. If not, this modifier aborts and the modifier of dexterity - CloneNamedFileBlobs - can do its work.