### PR TITLE
avoid an error with BTrees 4.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- In ShadowStorage's `isRegistered` method, avoid checking
+  for a history_id of None in the storage's BTree.
+  This fixes compatibility with BTrees 4.x,
+  which disallows comparing keys to None.
+  [davisagli]
 
 
 2.2.22 (2016-11-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ New features:
 
 Bug fixes:
 
-- In ShadowStorage's `isRegistered` method, avoid checking
-  for a history_id of None in the storage's BTree.
+- In ShadowStorage's `isRegistered` and `getHistory` methods,
+  avoid checking for a history_id of None in the storage's BTree.
   This fixes compatibility with BTrees 4.x,
   which disallows comparing keys to None.
   [davisagli]

--- a/Products/CMFEditions/ZVCStorageTool.py
+++ b/Products/CMFEditions/ZVCStorageTool.py
@@ -773,6 +773,8 @@ class ShadowStorage(Persistent):
         Returns None if ``autoAdd`` is False and the history
         does not exist. Else prepares and returns an empty history.
         """
+        if history_id is None:
+            return None
         # Create a new history if there isn't one yet
         if autoAdd and not self.isRegistered(history_id):
             self._storage[history_id] = ShadowHistory()

--- a/Products/CMFEditions/ZVCStorageTool.py
+++ b/Products/CMFEditions/ZVCStorageTool.py
@@ -755,14 +755,16 @@ class ShadowStorage(Persistent):
     Only cares about containerish operations.
     """
     def __init__(self):
-        # Using a OOBtree to allow history ids of any type. The type
-        # of the history ids higly depends on the unique id tool which
-        # we isn't under our control.
+        # Using an OOBtree to allow history ids of any type. The type
+        # of the history ids highly depends on the unique id tool which
+        # isn't under our control.
         self._storage = OOBTree()
 
     def isRegistered(self, history_id):
         """Returns True if a History With the Given History id Exists
         """
+        if history_id is None:
+            return False
         return history_id in self._storage
 
     def getHistory(self, history_id, autoAdd=False):


### PR DESCRIPTION
 In ShadowStorage's `isRegistered` and `getHistory` methods, avoid checking for a history_id of None in the storage's BTree. This fixes compatibility with BTrees 4.x, which disallows comparing keys to None.