### PR TITLE
Purge older versions of content about to be removed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Purge all old revisions of content about to be removed.
+  [tschorr]
 
 New features:
 

--- a/Products/CMFEditions/configure.zcml
+++ b/Products/CMFEditions/configure.zcml
@@ -38,6 +38,10 @@
     <subscriber for="*
                      Products.Archetypes.interfaces.IObjectEditedEvent"
                 handler=".subscriber.objectEdited" />
+
+    <subscriber for="*
+                     zope.lifecycleevent.interfaces.IObjectRemovedEvent"
+                handler=".subscriber.object_removed" />
   </configure>
 
 </configure>

--- a/Products/CMFEditions/subscriber.py
+++ b/Products/CMFEditions/subscriber.py
@@ -74,9 +74,6 @@ def object_removed(obj, event):
     """
     if not IContentish.providedBy(obj):
         return
-    obj, histid = dereference(obj)
-    if histid is None:
-        return
     try:
         histories_storage = getToolByName(obj, 'portal_historiesstorage')
         repo_tool = getToolByName(obj, 'portal_repository')
@@ -85,6 +82,9 @@ def object_removed(obj, event):
         # This occurs in some Products.CMFDiffTool and
         # Products.CMFTestCase tests for 4.3.x. Maybe it should
         # be fixed there.
+        return
+    obj, histid = dereference(obj)
+    if histid is None:
         return
     metadata = repo_tool.getHistoryMetadata(obj)
     try:

--- a/Products/CMFEditions/subscriber.py
+++ b/Products/CMFEditions/subscriber.py
@@ -26,8 +26,8 @@ $Id: ArchivistTool.py,v 1.15 2005/06/24 11:34:08 gregweb Exp $
 from zope.i18nmessageid import MessageFactory
 from Acquisition import aq_get
 
-from plone import api
 from Products.CMFCore.interfaces import IContentish
+from Products.CMFCore.utils import getToolByName
 from Products.CMFEditions.utilities import\
     isObjectChanged, maybeSaveVersion, dereference
 from Products.CMFEditions.interfaces.IModifier import\
@@ -77,8 +77,8 @@ def object_removed(obj, event):
     obj, histid = dereference(obj)
     if histid is None:
         return
-    histories_storage = api.portal.get_tool('portal_historiesstorage')
-    repo_tool = api.portal.get_tool('portal_repository')
+    histories_storage = getToolByName(obj, 'portal_historiesstorage')
+    repo_tool = getToolByName(obj, 'portal_repository')
     metadata = repo_tool.getHistoryMetadata(obj)
     try:
         num_versions = metadata.getLength(countPurged=False)

--- a/Products/CMFEditions/subscriber.py
+++ b/Products/CMFEditions/subscriber.py
@@ -77,8 +77,15 @@ def object_removed(obj, event):
     obj, histid = dereference(obj)
     if histid is None:
         return
-    histories_storage = getToolByName(obj, 'portal_historiesstorage')
-    repo_tool = getToolByName(obj, 'portal_repository')
+    try:
+        histories_storage = getToolByName(obj, 'portal_historiesstorage')
+        repo_tool = getToolByName(obj, 'portal_repository')
+    except AttributeError:
+        # XXX If tools are missing, there is nothing we can do.
+        # This occurs in some Products.CMFDiffTool and
+        # Products.CMFTestCase tests for 4.3.x. Maybe it should
+        # be fixed there.
+        return
     metadata = repo_tool.getHistoryMetadata(obj)
     try:
         num_versions = metadata.getLength(countPurged=False)

--- a/Products/CMFEditions/subscriber.py
+++ b/Products/CMFEditions/subscriber.py
@@ -80,7 +80,13 @@ def object_removed(obj, event):
     histories_storage = api.portal.get_tool('portal_historiesstorage')
     repo_tool = api.portal.get_tool('portal_repository')
     metadata = repo_tool.getHistoryMetadata(obj)
-    num_versions = metadata.getLength(countPurged=False)
+    try:
+        num_versions = metadata.getLength(countPurged=False)
+    except AttributeError:
+        # portal_historiesstorage will return
+        # an empty list in certain cases,
+        # do nothing
+        return
     current = metadata.retrieve(num_versions - 1)
     sys_metadata = current['metadata']['sys_metadata']
     if ('parent' in sys_metadata) and \

--- a/Products/CMFEditions/tests/test_CopyModifyMergeRepositoryTool.py
+++ b/Products/CMFEditions/tests/test_CopyModifyMergeRepositoryTool.py
@@ -199,11 +199,21 @@ class TestCopyModifyMergeRepositoryTool(TestCopyModifyMergeRepositoryToolBase):
         self.portal.invokeFactory(doc_type, 'doc_tmp')
         doc = self.portal.doc_tmp
         portal_hidhandler.setUid(doc, history_id, check_uniqueness=True)
-        vdata = portal_repository.retrieve(doc, selector=0)
-        self.failUnless(verifyObject(IVersionData, vdata))
-        self.assertEqual(vdata.object.text, 'text v1')
-        vdata = portal_repository.retrieve(doc, selector=1)
-        self.assertEqual(vdata.object.text, 'text v2')
+        self.assertRaises(
+            AttributeError,
+            portal_repository.retrieve,
+            doc,
+            selector=0)
+        #vdata = portal_repository.retrieve(doc, selector=0)
+        #self.failUnless(verifyObject(IVersionData, vdata))
+        #self.assertEqual(vdata.object.text, 'text v1')
+        self.assertRaises(
+              AttributeError,
+              portal_repository.retrieve,
+              doc,
+              selector=1)
+        #vdata = portal_repository.retrieve(doc, selector=1)
+        #self.assertEqual(vdata.object.text, 'text v2')
 
     def test07_restoreDeletedObject(self):
         portal_repository = self.portal.portal_repository
@@ -220,10 +230,16 @@ class TestCopyModifyMergeRepositoryTool(TestCopyModifyMergeRepositoryToolBase):
         # delete the object we want to retrieve later
         self.portal.manage_delObjects(ids=['doc'])
         self.failIf('doc' in self.portal.objectIds())
-        portal_repository.restore(history_id, selector=0, container=self.portal)
-        self.failUnless('doc' in self.portal.objectIds())
-        restored = self.portal.doc
-        self.assertEqual(restored.text, 'text v1')
+        self.assertRaises(
+            AttributeError,
+            portal_repository.restore,
+            history_id,
+            selector=0,
+            container=self.portal)
+        #portal_repository.restore(history_id, selector=0, container=self.portal)
+        #self.failUnless('doc' in self.portal.objectIds())
+        #restored = self.portal.doc
+        #self.assertEqual(restored.text, 'text v1')
 
     def test07_restoreDeletedObjectWithNewId(self):
         portal_repository = self.portal.portal_repository
@@ -240,11 +256,18 @@ class TestCopyModifyMergeRepositoryTool(TestCopyModifyMergeRepositoryToolBase):
         # delete the object we want to retrieve later
         self.portal.manage_delObjects(ids=['doc'])
         self.failIf('doc' in self.portal.objectIds())
-        portal_repository.restore(history_id, selector=0,
-                                         container=self.portal, new_id='doc2')
-        self.failUnless('doc2' in self.portal.objectIds())
-        restored = self.portal.doc2
-        self.assertEqual(restored.text, 'text v1')
+        self.assertRaises(
+            AttributeError,
+            portal_repository.restore,
+            history_id,
+            selector=0,
+            container=self.portal,
+            new_id='doc2')
+        #portal_repository.restore(history_id, selector=0,
+        #                                 container=self.portal, new_id='doc2')
+        #self.failUnless('doc2' in self.portal.objectIds())
+        #restored = self.portal.doc2
+        #self.assertEqual(restored.text, 'text v1')
 
     def test08_purgingDisallowedWithoutPurgingPolicy(self):
         portal_repository = self.portal.portal_repository


### PR DESCRIPTION
Current behavior in ``P.CMFEditions`` is to keep the history of deleted content in the DB. ``P.CMFEditions`` offers an API to restore revisions of deleted content, but there is no possibility for the end user to do so ttw, leaving potentially huge amounts of inaccessible/unnecessary data in the DB.
Suggestion: When removing content, also purge older revisions.