### PR TITLE
changed label 'Working Copy' to 'Current revision' to avoid mess with…

### DIFF
--- a/Products/CMFEditions/browser/templates/versions_history_form.pt
+++ b/Products/CMFEditions/browser/templates/versions_history_form.pt
@@ -54,7 +54,7 @@
                     tal:condition="isModified">
                   <td class="VersionId"
                       tal:define="id current/version_id;">
-                    <span i18n:translate="">Working Copy</span>
+                    <span i18n:translate="">Current revision</span>
                   </td>
                   <td class="VersionUser">
                     <span tal:replace="context/Creator">user</span>
@@ -101,7 +101,7 @@
                                 even repeat/vdatai/even;"
                     tal:attributes="class python:(current_version and 'CurrentVersion' or '') + (even and ' even' or '')">
                   <td class="VersionId">
-                    <span tal:condition="current_version" i18n:translate="">Working Copy</span>
+                    <span tal:condition="current_version" i18n:translate="">Current revision</span>
                     <span tal:condition="not:current_version" tal:content="id">1</span>
                     <a href="#"
                        class="version-table-version"

--- a/news/55.bugfix
+++ b/news/55.bugfix
@@ -1,0 +1,1 @@
+Replaced label 'Working Copy' with 'Current revision' [rristow]


### PR DESCRIPTION
… plone.app.iterate product

Just a small change to avoid people to confuse the "current revision" of an object (in the history) with the "working copy" from plone.app.iterate. - #54 