### PR TITLE
Fix success() responses in browser views for AT types

### DIFF
--- a/Products/CMFEditions/browser/views.py
+++ b/Products/CMFEditions/browser/views.py
@@ -13,7 +13,7 @@ from Products.statusmessages.interfaces import IStatusMessage
 class UpdateVersionOnEditView(BrowserView):
 
     def success(self):
-        return self.context.restrictedTraverse('content_edit')
+        self.request.response.redirect('view')
 
     def __call__(self):
         context = aq_inner(self.context)
@@ -39,7 +39,7 @@ class UpdateVersionOnEditView(BrowserView):
 class UpdateVersionBeforeEditView(BrowserView):
 
     def success(self):
-        self.request.response.redirect('view')
+        return self.context.restrictedTraverse('content_edit')
 
     def __call__(self):
         context = aq_inner(self.context)

--- a/news/62.bugfix
+++ b/news/62.bugfix
@@ -1,0 +1,1 @@
+Fix success() responses in controller actions browser views for AT types


### PR DESCRIPTION
Fix success() responses in controller actions browser views for AT types (Fixes #62)