### PR TITLE
Added upgrade step to remove broken AT modifiers from portal_modifier.

### DIFF
--- a/Products/CMFEditions/profiles.zcml
+++ b/Products/CMFEditions/profiles.zcml
@@ -32,4 +32,13 @@
            handler=".setuphandlers.installSkipRegistryBasesPointersModifier" />
     </genericsetup:upgradeSteps>
 
+    <genericsetup:upgradeSteps
+        source="4"
+        destination="10"
+        profile="Products.CMFEditions:CMFEditions">
+        <genericsetup:upgradeStep
+           title="Remove old broken Archetypes modifiers."
+           handler=".setuphandlers.removeBrokenModifiers" />
+    </genericsetup:upgradeSteps>
+
 </configure>

--- a/Products/CMFEditions/profiles/default/metadata.xml
+++ b/Products/CMFEditions/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4</version>
+  <version>10</version>
 </metadata>

--- a/Products/CMFEditions/setuphandlers.py
+++ b/Products/CMFEditions/setuphandlers.py
@@ -6,6 +6,11 @@ CMFEditions setup handlers.
 from Products.CMFCore.utils import getToolByName
 from Products.CMFEditions import StandardModifiers
 
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 
 def importVarious(context):
     """
@@ -31,3 +36,23 @@ def installSkipRegistryBasesPointersModifier(context):
     """Upgrade step to install the component registry bases modifier."""
     portal_modifier = getToolByName(context, 'portal_modifier', None)
     StandardModifiers.install(portal_modifier, ['SkipRegistryBasesPointers'])
+
+
+def removeBrokenModifiers(context):
+    """Remove broken modifiers.
+
+    For Plone 6 we have removed Archetypes support.
+    This includes removing classes for four Archetypes modifiers.
+    During normal usage you should not notice this.
+    But it is still better to remove them.
+    """
+    from Products.CMFEditions.interfaces.IModifier import IConditionalModifier
+
+    tool = getToolByName(context, 'portal_modifier', None)
+    for modifier_id, modifier in tool.objectItems():
+        if not IConditionalModifier.providedBy(modifier):
+            continue
+        if not modifier.isBroken():
+            continue
+        tool._delObject(modifier_id)
+        logger.info("Removed broken %s from portal_modifier.", modifier_id)

--- a/news/74.breaking
+++ b/news/74.breaking
@@ -1,4 +1,5 @@
 Removed support for Archetypes, Zope 2 and Python 2.
 Removed Archetypes-only modifiers: ``RetainATRefs``, ``NotRetainATRefs``, ``SkipBlobs``, ``CloneBlobs``.
+Added upgrade step to remove these modifiers from the ``portal_modifier`` tool.
 This is for Plone 6 only.
 [maurits]


### PR DESCRIPTION
I let the metadata.xml version jump from 4 to 10 to leave room on branch 3.x for version increases.

Note that CMFEditions upgrade steps are applied automatically when running plone-upgrade,
because it is in the `ADDON_LIST` in `CMFPlone.MigrationTool`.

cc @agitator 