### PR TITLE
fix test by explicitly reindexing

### DIFF
--- a/Products/CMFEditions/tests/test_IntegrationTests.py
+++ b/Products/CMFEditions/tests/test_IntegrationTests.py
@@ -394,6 +394,7 @@ class TestIntegration(CMFEditionsBaseTestCase):
         doc.text = RichTextValue("Plain text", "text/plain", "text/plain")
         portal_repo.applyVersionControl(doc)
         doc.text = RichTextValue("blahblah", "text/plain", "text/plain")
+        doc.reindexObject(idxs=["SearchableText"])
         portal_repo.save(doc)
         # Test that catalog has current value
         results = cat(SearchableText="Plain Text")

--- a/news/89.bugfix
+++ b/news/89.bugfix
@@ -1,0 +1,2 @@
+Fix test to work with updated CMFUid.
+[davisagli]


### PR DESCRIPTION
This reindexing used to be triggered implicitly by creation of a CMF UID while saving the object in portal_repository, but after https://github.com/zopefoundation/Products.CMFUid/pull/21 that no longer includes the SearchableText index.