### PR TITLE
Fix object remains locked after version retrieved

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,6 @@ Bug fixes:
 
 - - Only fire ObjectModifiedEvent once when an item is reverted to an old version. [davisagli] (#90)
 
-
 4.0.0b1 (2022-07-21)
 --------------------
 

--- a/Products/CMFEditions/CopyModifyMergeRepositoryTool.py
+++ b/Products/CMFEditions/CopyModifyMergeRepositoryTool.py
@@ -55,6 +55,7 @@ from Products.CMFEditions.utilities import wrap
 from Products.CMFEditions.VersionPolicies import VersionPolicy
 from ZODB.broken import Broken
 from zope.interface import implementer
+from plone.locking.interfaces import ILockable
 
 import logging
 import time
@@ -663,6 +664,7 @@ class CopyModifyMergeRepositoryTool(UniqueObject, SimpleItem):
             if inplace:
                 self._fixIds(obj)
                 self._fixupCatalogData(obj)
+                self._unlock(obj)
 
     def _fixupCatalogData(self, obj):
         """Reindex the object, otherwise the catalog will certainly
@@ -714,6 +716,13 @@ class CopyModifyMergeRepositoryTool(UniqueObject, SimpleItem):
                     obj._setObject(temp_id, child)
                     all_ids.append(temp_id)
 
+    def _unlock(self, obj):
+        try:
+            lockable = ILockable(obj)
+        except TypeError:
+            lockable = None
+        if lockable:
+            lockable.unlock()
 
 @implementer(IVersionData)
 class VersionData:

--- a/news/93.bugfix
+++ b/news/93.bugfix
@@ -1,0 +1,1 @@
+Fix object remains locked after version retrieved


### PR DESCRIPTION
After a version is retrieved from history, the object remains locked.

This is a tentative fix and work in progress.