### PR TITLE
Allow principal in sys_metadata with ArchivistTool init

### DIFF
--- a/Products/CMFEditions/ArchivistTool.py
+++ b/Products/CMFEditions/ArchivistTool.py
@@ -455,7 +455,7 @@ class PreparedObject:
         sys_metadata["comment"] = sys_metadata.get("comment", "")
         sys_metadata["timestamp"] = sys_metadata.get("timestamp", int(time.time()))
         sys_metadata["originator"] = sys_metadata.get("originator", None)
-        sys_metadata["principal"] = getUserId()
+        sys_metadata["principal"] = sys_metadata.get("principal", getUserId())
         sys_metadata["approxSize"] = approxSize
         sys_metadata["parent"] = {
             "history_id": portal_uidhandler.register(parent),

--- a/news/101.bugfix
+++ b/news/101.bugfix
@@ -1,0 +1,1 @@
+Allow principal in sys_metadata with ArchivistTool init


### PR DESCRIPTION
See:
- https://github.com/collective/collective.exportimport/issues/216
- https://github.com/collective/collective.exportimport/pull/217
