### PR TITLE
Allows versioning of the Plone Site type for the portal working copy to work

### DIFF
--- a/Products/CMFEditions/StandardModifiers.py
+++ b/Products/CMFEditions/StandardModifiers.py
@@ -26,6 +26,7 @@
 
 from AccessControl.class_init import InitializeClass
 from Acquisition import aq_base
+from Acquisition import ImplicitAcquisitionWrapper
 from OFS.ObjectManager import ObjectManager
 from plone.folder.default import DefaultOrdering
 from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2Base
@@ -673,6 +674,15 @@ class SkipParentPointers:
         parent_id = id(aq_base(parent))
 
         def persistent_id(obj):
+            # Avoid: TypeError: Can't pickle objects in acquisition wrappers.
+            if isinstance(obj, ImplicitAcquisitionWrapper):
+                return True
+            # Allows Plone Site to be serialized with pickle.
+            if (
+                hasattr(aq_base(obj), "portal_type")
+                and aq_base(obj).portal_type == "Plone Site"
+            ):
+                return
             if id(aq_base(obj)) == parent_id:
                 return True
             return None

--- a/Products/CMFEditions/profiles/default/repositorytool.xml
+++ b/Products/CMFEditions/profiles/default/repositorytool.xml
@@ -26,5 +26,9 @@
       <policy name="at_edit_autoversion" />
       <policy name="version_on_revert" />
     </type>
+    <type name="Plone Site">
+      <policy name="at_edit_autoversion" />
+      <policy name="version_on_revert" />
+    </type>
   </policymap>
 </repositorytool>

--- a/Products/CMFEditions/tests/test_ContentTypes.py
+++ b/Products/CMFEditions/tests/test_ContentTypes.py
@@ -105,6 +105,30 @@ class TestPloneContents(CMFEditionsBaseTestCase):
         self.assertEqual(content.text.raw, "text v1")
         self.metadata_test_one(content)
 
+    def test_plone_site(self):
+        portal_repository = self.portal_repository
+        content = self.portal
+        content.title = "content"
+        content.subject = ["content"]
+        content.description = "content"
+        content.contributors = ["content"]
+        content.language = "content"
+        content.rights = "content"
+        portal_repository.applyVersionControl(content, comment="save no 1")
+        content.title = "contentOK"
+        content.subject = ["contentOK"]
+        content.description = "contentOK"
+        content.contributors = ["contentOK"]
+        content.language = "contentOK"
+        content.rights = "contentOK"
+        portal_repository.save(content, comment="save no 2")
+        obj = portal_repository.retrieve(content, 0).object
+        self.metadata_test_one(obj)
+        obj = portal_repository.retrieve(content, 1).object
+        self.metadata_test_two(obj)
+        portal_repository.revert(content, 0)
+        self.metadata_test_one(content)
+
     def testImage(self):
         self.folder.invokeFactory("Image", id="image")
         portal_repository = self.portal_repository

--- a/news/113.feature
+++ b/news/113.feature
@@ -1,0 +1,1 @@
+Allows versioning of the Plone Site type for the portal working copy to work. @wesleybl


### PR DESCRIPTION
This is part of: https://github.com/plone/volto/issues/5284

For the working copy of `plone.app.iterate` to work on the `Plone Site` type, it is necessary that this type is versionable. See:

https://github.com/plone/plone.app.iterate/blob/1908aa1f4e9c95c37143fae88655469b72ea451a/plone/app/iterate/browser/control.py#L88-L90

This also allows the "Plone Site" type to be cloned.

`Products.CMFEditions` uses the `pickle` module to clone objects. See:

https://github.com/plone/Products.CMFEditions/blob/c80bc31af46bff45fee2908878b1f01190fda8d8/Products/CMFEditions/ArchivistTool.py#L210-L229

These changes prevent the error:

```
TypeError: Can't pickle objects in acquisition wrappers
```

When trying to serialize an `ImplicitAcquisitionWrapper` object with the pickle dump. This error occurred when trying to check in a Plone Site type with `plone.app.iterate`.

These changes also allow the Plone Site type to be serialized with the pickle. When the `persistent_id` method of `SkipParentPointers` returns something other than None, the object is not serialized. So we need to make sure it returns None for the Plone Site type.