### PR TITLE
fix(portal_repository): retrieve-rollback changes made in wrapping pa…

### DIFF
--- a/Products/CMFEditions/CopyModifyMergeRepositoryTool.py
+++ b/Products/CMFEditions/CopyModifyMergeRepositoryTool.py
@@ -514,8 +514,8 @@ class CopyModifyMergeRepositoryTool(UniqueObject, SimpleItem):
             inplace=False,
             countPurged=countPurged,
         )
-        saved.rollback()
         wrapped = wrap(vd.data.object, aq_parent(aq_inner(obj)))
+        saved.rollback()
         return VersionData(wrapped, vd.preserved_data, vd.sys_metadata, vd.app_metadata)
 
     def _recursiveRetrieve(

--- a/news/120.bugfix
+++ b/news/120.bugfix
@@ -1,0 +1,2 @@
+Avoid registering the parent in the current ZODB transaction while retrieving an old
+version. This helps avoid CSRF errors from plone.protect. @nileshgulia1


### PR DESCRIPTION
…rent to current obj.

When accessing a specific version of a content obj through volto, the serializer get's the version through portal_repository retrieve method, where it wraps the obj with parent to establish a fresh acquisition chain. 
https://github.com/plone/Products.CMFEditions/blob/847ccd1c0a5c93c9f9aee2405db4e65d2db7d205/Products/CMFEditions/utilities.py#L139

The parent obj gets written temporarily causing a side-effect in plone.protect triggering the code https://github.com/plone/plone.protect/blob/213f1c4da8cc7ce330edcc813868bbcdc2d1eecb/plone/protect/auto.py#L220
and making parent as _registered_object.

Maybe we can rollback the temporary changes in wrap using transaction rollback. Thus, including the wrap inside the savepoint. Let me know your thoughts. Thank you.